### PR TITLE
Adds support for overriding the Host header to origin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ rules:
 
 ## Host header
 
-A rule with `hostheader: original` will use what the incoming request used. `hostheader: destination` will use the rule destination's host and port, which is the default. An override, `hostheader: override.example.com:9000` is used as-is.
+A rule with `hostheader: original` will use what the incoming request used. `hostheader: destination` will use the rule destination's host and port, which is the default. An override, `hostheader: app2.example.com:9000` is used as-is.
 
 ```yaml
 rules:
     - destination: https://richie-appconfig.herokuapp.com/v1/$1
       pattern: app.example.com/config/v1/*
-      hostheader: override.example.com:9000
+      hostheader: app2.example.com:9000
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ rules:
 
 ## Host header
 
-A rule with `hostheader: client` will use what the incoming request used. `hostheader: destination` will use the rule destination's host and port, which is the default. An override, `hostheader: override.example.com:9000` is used as-is.
+A rule with `hostheader: original` will use what the incoming request used. `hostheader: destination` will use the rule destination's host and port, which is the default. An override, `hostheader: override.example.com:9000` is used as-is.
 
 ```yaml
 rules:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ rules:
       recompression: true
 ```
 
+## Host header
+
+A rule with `hostheader: client` will use what the incoming request used. `hostheader: destination` will use the rule destination's host and port, which is the default. An override, `hostheader: override.example.com:9000` is used as-is.
+
+```yaml
+rules:
+    - destination: https://richie-appconfig.herokuapp.com/v1/$1
+      pattern: app.example.com/config/v1/*
+      hostheader: override.example.com:9000
+```
+
+
+
 ## Traffic Copying
 
 In addition to proxying requests, rrrouter can copy traffic to a host without reporting this to the user.

--- a/integrationtest/common.go
+++ b/integrationtest/common.go
@@ -121,6 +121,10 @@ func (sh *ServerHelper) getURLQueryWithBody(path string, testServerURL string, q
 			req.Header.Add(hn, hv)
 		}
 	}
+	host := header.Get("Host")
+	if len(host) > 0 {
+		req.Host = host
+	}
 	reqdump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		sh.Test.Fatal("Error dumping request:", err)

--- a/integrationtest/successful_gets_test.go
+++ b/integrationtest/successful_gets_test.go
@@ -701,7 +701,7 @@ func TestConnection_host_header_behaviors(t *testing.T) {
 	require.Equal(t, "example.com", originHostHeader)
 	targetServer.Close()
 
-	// HostHeaderTarget
+	// HostHeaderDestination
 
 	receivedRequest = false
 	originHostHeader = ""
@@ -717,7 +717,7 @@ func TestConnection_host_header_behaviors(t *testing.T) {
 			Pattern:     "example.com/t/*",
 			Destination: fmt.Sprintf("%s/$1", targetServer.URL),
 			Internal:    false,
-			HostHeader:  "target",
+			HostHeader:  "destination",
 		},
 	}, sh.Logger)
 	require.Nil(t, err)

--- a/integrationtest/successful_gets_test.go
+++ b/integrationtest/successful_gets_test.go
@@ -670,7 +670,7 @@ func TestConnection_host_header_behaviors(t *testing.T) {
 	require.Equal(t, sUrl.Host, originHostHeader)
 	targetServer.Close()
 
-	// HostHeaderClient
+	// HostHeaderOriginal
 
 	receivedRequest = false
 	originHostHeader = ""
@@ -686,7 +686,7 @@ func TestConnection_host_header_behaviors(t *testing.T) {
 			Pattern:     "example.com/t/*",
 			Destination: fmt.Sprintf("%s/$1", targetServer.URL),
 			Internal:    false,
-			HostHeader:  "client",
+			HostHeader:  "original",
 		},
 	}, sh.Logger)
 	require.Nil(t, err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -335,7 +335,7 @@ func (r *router) createProxyRequest(req *http.Request, internal bool, hostHeader
 	switch hostHeader.Behavior {
 	case HostHeaderDefault, HostHeaderDestination:
 		break
-	case HostHeaderClient:
+	case HostHeaderOriginal:
 		preq.Host = req.Host
 	case HostHeaderOverride:
 		preq.Host = hostHeader.Override

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -333,7 +333,7 @@ func (r *router) createProxyRequest(req *http.Request, internal bool, hostHeader
 
 	preq.Header = filterHeader(req.Header, nonForwardedHeaderNames)
 	switch hostHeader.Behavior {
-	case HostHeaderDefault, HostHeaderTarget:
+	case HostHeaderDefault, HostHeaderDestination:
 		break
 	case HostHeaderClient:
 		preq.Host = req.Host

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -17,10 +17,25 @@ type Rule struct {
 	methods       map[string]bool
 	ruleType      ruleType
 	recompression bool
+	hostHeader    HostHeader
 }
 
+type HostHeader struct {
+	Behavior HostHeaderBehavior
+	Override string
+}
+
+type HostHeaderBehavior int
+
+const (
+	HostHeaderDefault HostHeaderBehavior = iota
+	HostHeaderClient
+	HostHeaderOverride
+	HostHeaderTarget
+)
+
 // NewRule builds a new Rule
-func NewRule(pattern, destination string, internal bool, methods map[string]bool, ruleType ruleType, recompression bool) (*Rule, error) {
+func NewRule(pattern, destination string, internal bool, methods map[string]bool, ruleType ruleType, hostHeader HostHeader, recompression bool) (*Rule, error) {
 	lowpat := strings.ToLower(pattern)
 	addAnyProto := !(strings.HasPrefix(lowpat, "http://") || strings.HasPrefix(lowpat, "https://"))
 	inputParts := strings.Split(pattern, "*")
@@ -50,6 +65,7 @@ func NewRule(pattern, destination string, internal bool, methods map[string]bool
 		internal:      internal,
 		methods:       methods,
 		ruleType:      ruleType,
+		hostHeader:    hostHeader,
 		recompression: recompression,
 	}
 

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -29,7 +29,7 @@ type HostHeaderBehavior int
 
 const (
 	HostHeaderDefault HostHeaderBehavior = iota
-	HostHeaderClient
+	HostHeaderOriginal
 	HostHeaderOverride
 	HostHeaderDestination
 )

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -31,7 +31,7 @@ const (
 	HostHeaderDefault HostHeaderBehavior = iota
 	HostHeaderClient
 	HostHeaderOverride
-	HostHeaderTarget
+	HostHeaderDestination
 )
 
 // NewRule builds a new Rule

--- a/proxy/rule_test.go
+++ b/proxy/rule_test.go
@@ -109,7 +109,7 @@ func TestRule(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r, err := NewRule(test.pat, test.dest, false, map[string]bool{}, ruleTypeProxy, false)
+		r, err := NewRule(test.pat, test.dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false)
 		if err != nil && !test.shouldError {
 			t.Errorf("Unexpected error compiling rule from %q, %q: %s", test.pat, test.dest, err)
 			continue

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -41,6 +41,7 @@ type RuleSource struct {
 	Destination   string   `json:"destination"`
 	Internal      bool     `json:"internal"`
 	Type          *string  `json:"type"`
+	HostHeader    string   `json:"hostheader"`
 	Recompression bool     `json:"recompression"`
 }
 
@@ -75,11 +76,22 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 				return nil, fmt.Errorf("unrecognized rule type %q", ruleType)
 			}
 		}
+		hostHeader := HostHeader{Behavior: HostHeaderDefault}
+		switch rsrc.HostHeader {
+		case "":
+			hostHeader = HostHeader{Behavior: HostHeaderDefault}
+		case "client":
+			hostHeader = HostHeader{Behavior: HostHeaderClient}
+		case "target":
+			hostHeader = HostHeader{Behavior: HostHeaderTarget}
+		default:
+			hostHeader = HostHeader{Behavior: HostHeaderOverride, Override: rsrc.HostHeader}
+		}
 		recompression := false
 		if rsrc.Recompression {
 			recompression = true
 		}
-		rule, err := NewRule(rsrc.Pattern, rsrc.Destination, rsrc.Internal, methodMap, ruleType, recompression)
+		rule, err := NewRule(rsrc.Pattern, rsrc.Destination, rsrc.Internal, methodMap, ruleType, hostHeader, recompression)
 		if err != nil {
 			return nil, err
 		}

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -82,8 +82,8 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 			hostHeader = HostHeader{Behavior: HostHeaderDefault}
 		case "client":
 			hostHeader = HostHeader{Behavior: HostHeaderClient}
-		case "target":
-			hostHeader = HostHeader{Behavior: HostHeaderTarget}
+		case "destination":
+			hostHeader = HostHeader{Behavior: HostHeaderDestination}
 		default:
 			hostHeader = HostHeader{Behavior: HostHeaderOverride, Override: rsrc.HostHeader}
 		}

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -80,8 +80,8 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 		switch rsrc.HostHeader {
 		case "":
 			hostHeader = HostHeader{Behavior: HostHeaderDefault}
-		case "client":
-			hostHeader = HostHeader{Behavior: HostHeaderClient}
+		case "original":
+			hostHeader = HostHeader{Behavior: HostHeaderOriginal}
 		case "destination":
 			hostHeader = HostHeader{Behavior: HostHeaderDestination}
 		default:

--- a/proxy/ruleconfig_test.go
+++ b/proxy/ruleconfig_test.go
@@ -54,6 +54,40 @@ func TestConfigParse_success(t *testing.T) {
 	require.Equal(t, ruleMatchResults.proxyMatch.target, "http://richie-barserver.herokuapp.com/v1/flarp/blart")
 }
 
+func TestConfigParse_host_headers(t *testing.T) {
+	src := `{"rules": [
+        {
+            "pattern": "api.example.com/foo/*",  
+            "destination": "http://localhost:1000/v1/$1",
+        },
+        {
+            "pattern": "api.example.com/bar/*", 
+            "destination": "http://localhost:1000/v1/$1",
+			"hostheader": "client"
+        },
+        {
+            "pattern": "api.example.com/bar/*", 
+            "destination": "http://localhost:1000/v1/$1",
+			"hostheader": "example.com:3800"
+        },
+        {
+            "pattern": "api.example.com/bar/*", 
+            "destination": "http://localhost:1000/v1/$1",
+			"hostheader": "target"
+        }
+        ]
+    }`
+	rules, err := ParseRules([]byte(src), testhelp.NewLogger(t))
+	require.Nil(t, err)
+	require.Equal(t, 4, len(rules.rules))
+	require.Equal(t, HostHeaderDefault, rules.rules[0].hostHeader.Behavior)
+	require.Equal(t, HostHeaderClient, rules.rules[1].hostHeader.Behavior)
+	require.Equal(t, HostHeaderOverride, rules.rules[2].hostHeader.Behavior)
+	require.Equal(t, "example.com:3800", rules.rules[2].hostHeader.Override)
+	require.Equal(t, HostHeaderTarget, rules.rules[3].hostHeader.Behavior)
+
+}
+
 func TestConfigParse_mismatched_wildcard_count_error(t *testing.T) {
 	src := `{"rules": [
         {

--- a/proxy/ruleconfig_test.go
+++ b/proxy/ruleconfig_test.go
@@ -73,7 +73,7 @@ func TestConfigParse_host_headers(t *testing.T) {
         {
             "pattern": "api.example.com/bar/*", 
             "destination": "http://localhost:1000/v1/$1",
-			"hostheader": "target"
+			"hostheader": "destination"
         }
         ]
     }`
@@ -84,7 +84,7 @@ func TestConfigParse_host_headers(t *testing.T) {
 	require.Equal(t, HostHeaderClient, rules.rules[1].hostHeader.Behavior)
 	require.Equal(t, HostHeaderOverride, rules.rules[2].hostHeader.Behavior)
 	require.Equal(t, "example.com:3800", rules.rules[2].hostHeader.Override)
-	require.Equal(t, HostHeaderTarget, rules.rules[3].hostHeader.Behavior)
+	require.Equal(t, HostHeaderDestination, rules.rules[3].hostHeader.Behavior)
 
 }
 

--- a/proxy/ruleconfig_test.go
+++ b/proxy/ruleconfig_test.go
@@ -63,7 +63,7 @@ func TestConfigParse_host_headers(t *testing.T) {
         {
             "pattern": "api.example.com/bar/*", 
             "destination": "http://localhost:1000/v1/$1",
-			"hostheader": "client"
+			"hostheader": "original"
         },
         {
             "pattern": "api.example.com/bar/*", 
@@ -81,7 +81,7 @@ func TestConfigParse_host_headers(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 4, len(rules.rules))
 	require.Equal(t, HostHeaderDefault, rules.rules[0].hostHeader.Behavior)
-	require.Equal(t, HostHeaderClient, rules.rules[1].hostHeader.Behavior)
+	require.Equal(t, HostHeaderOriginal, rules.rules[1].hostHeader.Behavior)
 	require.Equal(t, HostHeaderOverride, rules.rules[2].hostHeader.Behavior)
 	require.Equal(t, "example.com:3800", rules.rules[2].hostHeader.Override)
 	require.Equal(t, HostHeaderDestination, rules.rules[3].hostHeader.Behavior)

--- a/proxy/urlcreate_test.go
+++ b/proxy/urlcreate_test.go
@@ -57,7 +57,7 @@ func uparse(s string) *url.URL {
 }
 
 func createRule(pat, dest string) *Rule {
-	r, err := NewRule(pat, dest, false, map[string]bool{}, ruleTypeProxy, false)
+	r, err := NewRule(pat, dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A rule with `hostheader: client` will use what the request used. `target` will use the rule destination's host and port. `override` is used as-is. Default is `target`.