### PR TITLE
Run the command with user `rrrouter`. This is to be made use of when …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM debian:buster
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN update-ca-certificates
 COPY --from=0 /go/bin/richie-request-router .
+RUN useradd -s /bin/false rrrouter
+USER rrrouter
 ENTRYPOINT ["./richie-request-router"]
 CMD ["start"]
 


### PR DESCRIPTION
…separating file ownership in shared environments.