### PR TITLE
caching/disk: Store entries in filename derived subdirectories. 

### DIFF
--- a/caching/caching.go
+++ b/caching/caching.go
@@ -328,7 +328,12 @@ func (k Key) FsName() string {
 	if k.opaqueOrigin {
 		s += "opaqueOrigin"
 	}
-	return util.SHA1String([]byte(s))
+	name := util.SHA1String([]byte(s))
+	prefix := ""
+	for _, c := range name[:3] {
+		prefix += string(c) + "/"
+	}
+	return prefix + name
 }
 
 func (k Key) HasOpaqueOrigin() bool {

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -428,6 +428,10 @@ func (sw *storageWriter) WriteHeader(s int, h http.Header) {
 		sw.created = time.Now().Unix()
 	}
 	if sw.fd == nil {
+		err := createAllSubdirs(filepath.Dir(sw.path))
+		if err != nil {
+			panic(fmt.Sprintf("Could not create directory for path: %v", sw.path))
+		}
 		fd, err := os.Create(sw.path)
 		if err != nil {
 			exists, _ := pathExists(sw.path)
@@ -442,6 +446,15 @@ func (sw *storageWriter) WriteHeader(s int, h http.Header) {
 		}
 		sw.fd = fd
 	}
+}
+
+func createAllSubdirs(dir string) error {
+	_, err := os.Stat(dir)
+	if err == nil || !os.IsNotExist(err) {
+		return nil
+	}
+
+	return os.MkdirAll(dir, 0755)
 }
 
 func (sw *storageWriter) Write(p []byte) (n int, err error) {

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -150,6 +150,7 @@ func (s *storage) GetWriter(key Key, revalidate bool, closeNotifier *chan Key) S
 	}
 
 	return &storageWriter{key: key,
+		root:           s.path,
 		path:           fp,
 		wasRevalidated: revalidate,
 		closeFinisher: func(name string, size int64) {
@@ -387,6 +388,7 @@ func (s *storage) purgeableItemNames(purgeBytes int64) purgeableItems {
 type storageWriter struct {
 	key            Key
 	oldKey         *Key
+	root           string
 	path           string
 	invalidated    bool
 	closeFinisher  func(name string, size int64)
@@ -566,7 +568,7 @@ func (sw *storageWriter) WrittenFile() (*os.File, error) {
 
 func (sw *storageWriter) ChangeKey(k Key) error {
 	sw.log.Debugf("1: Gonna change %v to %v\n%v VS. %v\n", sw.key.FsName(), k.FsName(), sw.key, k)
-	newPath := filepath.Join(filepath.Dir(sw.path), k.FsName())
+	newPath := filepath.Join(sw.root, k.FsName())
 	exists, err := pathExists(newPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
An entry with hash "abcde" becomes "a/b/c/abcde" when stored on disk.