### PR TITLE
rrrouter: Persist atimes to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ cache-control: private
 
 Rrrouter includes a `richie-edge-cache` response header, with values being `miss`, `hit`, `revalidated`, `stale`, `pass` or `uncacheable`. If a rule should match and the response was not cached, the `richie-edge-cache` is omitted.
 
+### Access time storing
+
+For best performance it's recommended to set noatime on the mounted storage. Rrrouter stores access times for new entries in memory and will flush them underneath the configured cache path, up to `ATIME_LOG_SIZE_BYTES` bytes, ~3M records by default. When the maximum size is met, the log file is truncated by 10% starting from the earliest accesses. `ATIME_FLUSH_INTERVAL`, 30 seconds by default, specifies how often unique entry accesses--inside this interval--are appended to the log file. This log file is read upon startup and then removed. Disable with `ATIME_DISABLE` set to `"true"`. 
+
 ## System information
 
 There's an admin endpoint, `/__SYSTEMINFO`, for checking state of the system rrrouter is running on. The endpoint requires that the `ADMIN_NAME` and `ADMIN_PASS` environment variables are set.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Rrrouter includes a `richie-edge-cache` response header, with values being `miss
 
 ### Access time storing
 
-For best performance it's recommended to set noatime on the mounted storage. Rrrouter stores access times for new entries in memory and will flush them underneath the configured cache path, up to `ATIME_LOG_SIZE_BYTES` bytes, ~3M records by default. When the maximum size is met, the log file is truncated by 10% starting from the earliest accesses. `ATIME_FLUSH_INTERVAL`, 30 seconds by default, specifies how often unique entry accesses--inside this interval--are appended to the log file. This log file is read upon startup and then removed. Disable with `ATIME_DISABLE` set to `"true"`. 
+For best performance it's recommended to set noatime on the mounted storage. As this is the starting point, no atimes are attempted to be read from disk storage. Rrrouter stores access times for new entries in memory and will flush them underneath the configured cache path, up to `ATIME_LOG_SIZE_BYTES` bytes, ~3M records by default. When the maximum size is met, the log file is truncated by 10% starting from the earliest accesses. `ATIME_FLUSH_INTERVAL`, 30 seconds by default, specifies how often unique entry accesses--inside this interval--are appended to the log file. This log file is read upon startup and then removed. Disable with `ATIME_DISABLE` set to `"true"`. 
 
 ## System information
 

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -508,12 +508,7 @@ func (s *storage) readStorableAccessTimes() (withAccessTime map[itemName]accesse
 		withAccessTime[itemName(name)] = accessedItem{accessTime: accessTime(atime), sizeKilobytes: size}
 	}
 	if err != io.EOF {
-		s.logger.Errorf("Reading access times failed with %v items read: %v", len(withAccessTime), err)
-	}
-
-	err = os.Remove(p)
-	if err != nil {
-		s.logger.Errorf("Could not remove atime file: %v", err)
+		s.logger.Warnf("Reading access times failed with %v items read: %v", len(withAccessTime), err)
 	}
 
 	return withAccessTime, nil

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -992,7 +992,7 @@ func (sw *storageWriter) Delete() error {
 
 	closeErr := sw.fd.Close()
 	err := os.Remove(sw.path)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		sw.log.Errorf("Could not remove path %v: %v. Close error was: %v", sw.path, err, closeErr)
 		return err
 	}

--- a/util/env.go
+++ b/util/env.go
@@ -1,0 +1,5 @@
+package util
+
+func EnvBool(s string) bool {
+	return s == "1" || s == "true" || s == "True" || s == "yes"
+}


### PR DESCRIPTION
For best performance it's recommended to set noatime on the mounted storage. Rrrouter stores access times for new entries in memory and will flush them underneath the configured cache path, up to `ATIME_LOG_SIZE_BYTES` bytes, ~3M records by default. When the maximum size is met, the log file is truncated by 10% starting from the earliest accesses. `ATIME_FLUSH_INTERVAL`, 30 seconds by default, specifies how often unique entry accesses--inside this interval--are appended to the log file. This log file is read upon startup and then removed. Disable with `ATIME_DISABLE` set to `"true"`. 