### PR TITLE
Fail health check when a storage can't be written to

### DIFF
--- a/integrationtest/caching_test.go
+++ b/integrationtest/caching_test.go
@@ -1823,6 +1823,10 @@ func (c *testCache) HasStorage(id string) bool {
 	return true
 }
 
+func (c *testCache) HealthCheck() error {
+	return nil
+}
+
 type testStorage struct {
 	s           caching.Storage
 	queriedKeys func(caching.Key)
@@ -1845,8 +1849,13 @@ func (ts *testStorage) Id() string {
 func (ts *testStorage) Update(cfg caching.StorageConfiguration) {
 
 }
+
 func (ts *testStorage) SetIsReplaced() {
 
+}
+
+func (ts *testStorage) WriteTest() (bool, error) {
+	return true, nil
 }
 
 func newTestStorage(s caching.Storage, queriedKeys func(caching.Key)) caching.Storage {

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,13 @@ func Run(conf *config.Config, router proxy.Router, logger *apexlog.Logger, cache
 func ConfigureServeMux(s *http.ServeMux, conf *config.Config, router proxy.Router, logger *apexlog.Logger, cache caching.Cache) {
 	s.Handle("/__SYSTEMINFO", basicAuth(showSystemInfo(), conf.AdminName, conf.AdminPass, "Restricted"))
 	s.HandleFunc("/__RRROUTER/health", func(w http.ResponseWriter, req *http.Request) {
+		if cache != nil {
+			if err := cache.HealthCheck(); err != nil {
+				w.WriteHeader(503)
+				fmt.Fprintf(w, "Unhealthy cache: %v", err)
+				return
+			}
+		}
 		fmt.Fprintf(w, "OK")
 	})
 	s.HandleFunc("/", cachingHandler(router, logger, conf, cache))


### PR DESCRIPTION
- `/__RRROUTER/health` will return HTTP 503 when any configured storages can't be written to