### PR TITLE
Lockless disk access times and miscellaneous fixes

### DIFF
--- a/caching/caching.go
+++ b/caching/caching.go
@@ -685,7 +685,7 @@ type CacheControlDirectives struct {
 }
 
 func (ccd CacheControlDirectives) DoNotCache() bool {
-	return ccd.Private || ccd.NoStore || (ccd.SMaxAge != nil && *ccd.SMaxAge == 0) || (ccd.MaxAge != nil && *ccd.MaxAge == 0)
+	return ccd.NoCache || ccd.Private || ccd.NoStore || (ccd.SMaxAge != nil && *ccd.SMaxAge == 0) || (ccd.MaxAge != nil && *ccd.MaxAge == 0)
 }
 
 func (ccd CacheControlDirectives) CanStaleIfError(age int64) bool {

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -213,7 +213,7 @@ func NewDiskStorage(id string, path string, size int64, logger *apexlog.Logger, 
 	}
 
 	go s.runSizeLimiter()
-	disablePersistentAtime := util.EnvBool(os.Getenv("ATIME_DISABLE"))
+	disablePersistentAtime := util.EnvBool("ATIME_DISABLE")
 	if !disablePersistentAtime {
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
@@ -645,7 +645,7 @@ func (s *storage) signalListener(c chan os.Signal) {
 		switch sig {
 		case syscall.SIGTERM, syscall.SIGABRT, syscall.SIGINT:
 			s.logger.Infof("Received %v, running exit handlers", sig)
-			if !util.EnvBool(os.Getenv("ATIME_DISABLE")) {
+			if !util.EnvBool("ATIME_DISABLE") {
 				s.itemsChan <- &itemWithOp{op: opFlushStorable}
 				time.Sleep(time.Second)
 			}

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -199,19 +198,18 @@ type DiskStorage struct {
 func NewDiskStorage(id string, path string, size int64, logger *apexlog.Logger, now func() time.Time) Storage {
 	createStoragePath(path)
 	s := &storage{
-		id:                        id,
-		path:                      path,
-		maxSizeBytes:              size,
-		startedAt:                 time.Now().Unix(),
-		sizeBytes:                 0,
-		itemsLock:                 sync.Mutex{},
-		withAccessTime:            make(map[itemName]accessedItem, 0),
-		storableAccessedItems:     make(map[itemName]storableAccessedItem, 0),
-		withoutAccessTime:         make(map[itemName]item, 0),
-		storableAccessedItemsLock: sync.Mutex{},
-		atimesPath:                filepath.Join(path, "atimes"),
-		logger:                    logger,
-		now:                       now,
+		id:                    id,
+		path:                  path,
+		maxSizeBytes:          size,
+		startedAt:             time.Now().Unix(),
+		sizeBytes:             0,
+		itemsChan:             make(chan *itemWithOp, 100000),
+		withAccessTime:        make(map[itemName]accessedItem, 0),
+		storableAccessedItems: make(map[itemName]storableAccessedItem, 0),
+		withoutAccessTime:     make(map[itemName]item, 0),
+		atimesPath:            filepath.Join(path, "atimes"),
+		logger:                logger,
+		now:                   now,
 	}
 
 	go s.runSizeLimiter()
@@ -220,15 +218,15 @@ func NewDiskStorage(id string, path string, size int64, logger *apexlog.Logger, 
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
 		go s.signalListener(sigChan)
+		t := 30
+		if sleepTime := os.Getenv("ATIME_FLUSH_INTERVAL"); len(sleepTime) > 0 {
+			if it, err := strconv.Atoi(sleepTime); err == nil {
+				t = it
+			}
+		}
 		go func() {
 			for {
-				s.flushStorableAccessTimes()
-				t := 30
-				if sleepTime := os.Getenv("ATIME_FLUSH_INTERVAL"); len(sleepTime) > 0 {
-					if it, err := strconv.Atoi(sleepTime); err == nil {
-						t = it
-					}
-				}
+				s.itemsChan <- &itemWithOp{op: opFlushStorable}
 				time.Sleep(time.Second * time.Duration(t))
 			}
 		}()
@@ -253,18 +251,17 @@ type accessTime uint32
 type itemName string
 
 type storage struct {
-	id                        string
-	path                      string
-	maxSizeBytes              int64
-	startedAt                 int64
-	sizeBytes                 int64
-	itemsLock                 sync.Mutex
-	withAccessTime            map[itemName]accessedItem
-	withoutAccessTime         map[itemName]item
-	isReplaced                bool
-	atimesPath                string
-	storableAccessedItems     map[itemName]storableAccessedItem
-	storableAccessedItemsLock sync.Mutex
+	id                    string
+	path                  string
+	maxSizeBytes          int64
+	startedAt             int64
+	sizeBytes             int64
+	itemsChan             chan *itemWithOp
+	withAccessTime        map[itemName]accessedItem
+	withoutAccessTime     map[itemName]item
+	isReplaced            bool
+	atimesPath            string
+	storableAccessedItems map[itemName]storableAccessedItem
 
 	logger *apexlog.Logger
 	now    func() time.Time
@@ -273,6 +270,21 @@ type storage struct {
 type accessedItem struct {
 	accessTime    accessTime
 	sizeKilobytes uint32
+}
+
+type itemOp int
+
+const (
+	opAdd itemOp = iota
+	opAccessTime
+	opFlushStorable
+)
+
+type itemWithOp struct {
+	op                   itemOp
+	name                 itemName
+	accessedItem         *accessedItem
+	storableAccessedItem *storableAccessedItem
 }
 
 type storableAccessedItem struct {
@@ -310,13 +322,11 @@ func (s *storage) GetWriter(key Key, revalidate bool, closeNotifier *chan KeyInf
 		path:           fp,
 		wasRevalidated: revalidate,
 		closeFinisher: func(name string, size int64) {
-			s.itemsLock.Lock()
-			s.withAccessTime[itemName(name)] = accessedItem{
+			ai := accessedItem{
 				accessTime:    accessTime(time.Now().Unix() - s.startedAt),
 				sizeKilobytes: uint32(size / 1024),
 			}
-			s.sizeBytes += size
-			s.itemsLock.Unlock()
+			s.itemsChan <- &itemWithOp{op: opAdd, name: itemName(name), accessedItem: &ai}
 		}, now: func() time.Time {
 			return s.now()
 		}, closeNotifier: closeNotifier,
@@ -469,12 +479,10 @@ func (s *storage) readFiles(path string) int {
 			withoutAccessTime[itemName(prefixWithItemName(name)+name)] = item{sizeKilobytes: uint32(size / 1024)}
 		}
 	}
-	s.itemsLock.Lock()
 	for n, i := range withoutAccessTime {
 		s.withoutAccessTime[n] = i
 	}
 	s.sizeBytes += sizeBytes
-	s.itemsLock.Unlock()
 
 	return fileCount
 }
@@ -490,32 +498,60 @@ func (s *storage) runSizeLimiter() {
 		s.logger.Infof("Errored when reading access times: %v", err)
 	} else if len(withAccessTime) > 0 {
 		s.logger.Infof("Read access times of %v files in %v", len(withAccessTime), time.Now().Sub(t))
-		s.itemsLock.Lock()
 		t = time.Now()
 		for n, i := range withAccessTime {
 			s.withAccessTime[n] = i
 			delete(s.withoutAccessTime, n)
 		}
 		s.logger.Infof("Set access times of %v files in %v", len(withAccessTime), time.Now().Sub(t))
-		s.itemsLock.Unlock()
 	}
 
 	// Initialization done, go at it forever:
 
 	sleepTime := time.Second * 5
+	lastRun := time.Now().Add(-sleepTime)
+	printChanLen := false
 	for {
 		if s.isReplaced {
 			break
 		}
+
+		io := <-s.itemsChan
+		switch io.op {
+		case opAdd:
+			if io.accessedItem != nil {
+				s.withAccessTime[io.name] = *io.accessedItem
+				s.sizeBytes += int64(io.accessedItem.sizeKilobytes * 1024)
+			}
+		case opAccessTime:
+			if io.accessedItem != nil {
+				s.withAccessTime[io.name] = *io.accessedItem
+			}
+			if io.storableAccessedItem != nil {
+				s.storableAccessedItems[io.name] = *io.storableAccessedItem
+			}
+		case opFlushStorable:
+			s.flushStorableAccessTimes()
+		}
+
+		if printChanLen {
+			fmt.Println("itemsChan: ", len(s.itemsChan))
+			printChanLen = false
+		}
+
+		if time.Now().Sub(lastRun) < sleepTime {
+			continue
+		}
+
+		printChanLen = true
+
 		s.logger.Info(s.stats())
 		purgeable := purgeableItems{}
-		s.itemsLock.Lock()
 		if s.sizeBytes > s.maxSizeBytes {
 			purgeable = s.purgeableItemNames(s.sizeBytes - s.maxSizeBytes)
 		}
-		s.itemsLock.Unlock()
 		if len(purgeable.withAccessTimes) == 0 && len(purgeable.withoutAccessTimes) == 0 {
-			time.Sleep(sleepTime)
+			lastRun = time.Now()
 			continue
 		}
 
@@ -541,7 +577,6 @@ func (s *storage) runSizeLimiter() {
 		rmFiles(&purgeable.withoutAccessTimes, &removedWithoutAccessTimes)
 		rmFiles(&purgeable.withAccessTimes, &removedWithAccessTimes)
 
-		s.itemsLock.Lock()
 		for _, n := range removedWithAccessTimes {
 			sizeKb := s.withAccessTime[n].sizeKilobytes
 			delete(s.withAccessTime, n)
@@ -552,11 +587,10 @@ func (s *storage) runSizeLimiter() {
 			delete(s.withoutAccessTime, n)
 			s.sizeBytes -= int64(sizeKb * 1024)
 		}
-		s.itemsLock.Unlock()
 
 		s.logger.Infof("Removed %v / %v items to release at least %v MB",
 			len(removedWithoutAccessTimes)+len(removedWithAccessTimes), len(purgeable.withoutAccessTimes)+len(purgeable.withAccessTimes), purgeable.size/1024/1024)
-		time.Sleep(sleepTime)
+		lastRun = time.Now()
 	}
 }
 
@@ -612,7 +646,8 @@ func (s *storage) signalListener(c chan os.Signal) {
 		case syscall.SIGTERM, syscall.SIGABRT, syscall.SIGINT:
 			s.logger.Infof("Received %v, running exit handlers", sig)
 			if !util.EnvBool(os.Getenv("ATIME_DISABLE")) {
-				s.flushStorableAccessTimes()
+				s.itemsChan <- &itemWithOp{op: opFlushStorable}
+				time.Sleep(time.Second)
 			}
 			os.Exit(0)
 		}
@@ -620,9 +655,6 @@ func (s *storage) signalListener(c chan os.Signal) {
 }
 
 func (s *storage) readStorableAccessTimes() (withAccessTime map[itemName]accessedItem, err error) {
-	s.storableAccessedItemsLock.Lock()
-	defer s.storableAccessedItemsLock.Unlock()
-
 	p := s.atimesPath
 	f, err := os.Open(p)
 	if err != nil {
@@ -674,15 +706,11 @@ func (s *storage) readStorableAccessTimes() (withAccessTime map[itemName]accesse
 }
 
 func (s *storage) resetStorableAccessTimes() {
-	s.storableAccessedItemsLock.Lock()
 	s.storableAccessedItems = make(map[itemName]storableAccessedItem, 0)
-	s.storableAccessedItemsLock.Unlock()
 }
 
 func (s *storage) flushStorableAccessTimes() {
-	s.storableAccessedItemsLock.Lock()
 	defer s.resetStorableAccessTimes()
-	defer s.storableAccessedItemsLock.Unlock()
 
 	if len(s.storableAccessedItems) == 0 {
 		return
@@ -831,16 +859,9 @@ func (s *storage) flushStorableAccessTimes() {
 
 func (s *storage) setAccessTime(key Key, size int64) {
 	name := itemName(key.FsName())
-	storableItem := storableAccessedItem{time.Now().Unix(), uint32(size / 1024)}
-	s.storableAccessedItemsLock.Lock()
-	s.storableAccessedItems[name] = storableItem
-	s.storableAccessedItemsLock.Unlock()
-
 	item := accessedItem{accessTime(time.Now().Unix() - s.startedAt), uint32(size / 1024)}
-	s.itemsLock.Lock()
-	s.withAccessTime[name] = item
-	delete(s.withoutAccessTime, name)
-	s.itemsLock.Unlock()
+	storableItem := storableAccessedItem{time.Now().Unix(), uint32(size / 1024)}
+	s.itemsChan <- &itemWithOp{op: opAccessTime, name: name, accessedItem: &item, storableAccessedItem: &storableItem}
 }
 
 type storageWriter struct {

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -540,7 +540,7 @@ func (s *storage) runSizeLimiter() {
 		}
 
 		if printChanLen {
-			fmt.Println("itemsChan: ", len(s.itemsChan))
+			go mets.NewMetrics(nil, nil, nil).WithSampleRate(1).Mark("items channel length", len(s.itemsChan))
 			printChanLen = false
 		}
 

--- a/integrationtest/caching_test.go
+++ b/integrationtest/caching_test.go
@@ -3,6 +3,7 @@
 package integrationtest
 
 import (
+	"context"
 	"fmt"
 	apexlog "github.com/apex/log"
 	"github.com/c2h5oh/datasize"
@@ -1863,7 +1864,7 @@ type testCache struct {
 	getWriter   func(cacheId string, k caching.Key, revalidate bool) caching.CacheWriter
 }
 
-func (c *testCache) Get(s string, ri int, skipRevalidate bool, keys []caching.Key, w http.ResponseWriter, l *apexlog.Logger) (caching.CacheResult, caching.Key, error) {
+func (c *testCache) Get(ctx context.Context, s string, ri int, skipRevalidate bool, keys []caching.Key, w http.ResponseWriter, l *apexlog.Logger) (caching.CacheResult, caching.Key, error) {
 	if s != c.cacheId {
 		return caching.CacheResult{caching.NotFoundReader, nil, nil, nil, caching.CacheMetadata{Header: http.Header{}, Status: 200}, 0, false}, keys[0], nil
 	}
@@ -1892,8 +1893,8 @@ func (ts *testStorage) GetWriter(k caching.Key, r bool, c *chan caching.KeyInfo)
 	return ts.s.GetWriter(k, r, c)
 }
 
-func (ts *testStorage) Get(keys []caching.Key) (*os.File, caching.StorageMetadata, caching.Key, error) {
-	w, sm, key, err := ts.s.Get(keys)
+func (ts *testStorage) Get(ctx context.Context, keys []caching.Key) (*os.File, caching.StorageMetadata, caching.Key, error) {
+	w, sm, key, err := ts.s.Get(ctx, keys)
 	ts.queriedKeys(key)
 	return w, sm, key, err
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,207 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"github.com/richiefi/rrrouter/util"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+)
+
+/*
+	In the context-initiating function:
+	m := metrics.NewMetrics(or.URL.RequestURI(), senders, timeout)
+	ctx := context.WithValue(or.Context(), "metrics", m)
+	defer m.ReportAndClose(time.Now())
+
+	Deeper in the stack, where ctx is passed, at the start of the function:
+	defer m.FromContext(ctx).MarkTime(time.Now())
+
+	Mark specific points inside a function:
+	m.FromContext(ctx).MarkTimeWith("setAccessTime-Storable")
+*/
+
+type Metrics interface {
+	MarkTime(time.Time) Metrics
+	MarkTimeWith(string) Metrics
+	ReportAndClose(time.Time)
+}
+
+func NewMetrics(ctx interface{}, senders *[]Sender, timeout *time.Duration) Metrics {
+	m := metrics{}
+	m.ctx = ctx
+	m.times = make([]timeFunc, 0)
+	now := time.Now()
+	m.times = append(m.times, timeFunc{now, now, callerName(2), "", false})
+	m.timesL = sync.Mutex{}
+	m.rc = make(chan bool, 1)
+	m.timeout = timeout
+	if senders == nil {
+		if util.EnvBool("METRICS_DEBUG") {
+			ss := make([]Sender, 1)
+			ss[0] = &printSender{}
+			senders = &ss
+		}
+	}
+	m.senders = senders
+	go m.waitForReport()
+	return &m
+}
+
+type metrics struct {
+	ctx     interface{}
+	times   []timeFunc
+	timesL  sync.Mutex
+	rc      chan bool
+	senders *[]Sender
+	timeout *time.Duration
+}
+
+type Sender interface {
+	Send(ctx *interface{}, ts *[]timeFunc)
+}
+
+type timeFunc struct {
+	b  time.Time
+	d  time.Time
+	f  string
+	w  string
+	to bool
+}
+
+func (m *metrics) MarkTime(b time.Time) Metrics {
+	m.markTime(4, b, time.Now(), "", false)
+	return m
+}
+
+func (m *metrics) MarkTimeWith(s string) Metrics {
+	m.markTime(4, time.Now(), time.Now(), s, false)
+	return m
+}
+
+func (m *metrics) markTime(skip int, b, d time.Time, with string, to bool) {
+	m.timesL.Lock()
+	defer m.timesL.Unlock()
+	var f string
+	if to {
+		f = "timeout"
+	} else {
+		f = callerName(skip)
+	}
+	tf := timeFunc{
+		b:  b,
+		d:  d,
+		f:  f,
+		w:  with,
+		to: to,
+	}
+	m.times = append(m.times, tf)
+}
+
+func (m *metrics) markTimeout() {
+	now := time.Now()
+	m.markTime(4, now, now, "", true)
+}
+
+func FromContext(ctx context.Context) Metrics {
+	if ctx == nil {
+		return &dummyMetrics{}
+	}
+	if v := ctx.Value("metrics"); v != nil {
+		if cv, ok := v.(*metrics); ok {
+			return cv
+		}
+	}
+
+	return &dummyMetrics{}
+}
+
+func (m *metrics) ReportAndClose(b time.Time) {
+	m.markTime(4, b, time.Now(), "", false)
+	m.rc <- true
+}
+
+func (m *metrics) waitForReport() {
+	var to time.Duration
+	if m.timeout != nil {
+		to = *m.timeout
+	} else {
+		to = time.Second * 60
+	}
+	select {
+	case <-m.rc:
+		break
+	case <-time.After(to):
+		m.markTimeout()
+	}
+	if m.senders != nil {
+		for _, s := range *m.senders {
+			s.Send(&m.ctx, &m.times)
+		}
+	}
+}
+
+func callerName(skip int) string {
+	pc := make([]uintptr, 1)
+	runtime.Callers(skip, pc)
+	if f := runtime.FuncForPC(pc[0]); f != nil {
+		return f.Name()
+	}
+	return "unknown func"
+}
+
+type printSender struct {
+}
+
+type byB []timeFunc
+
+func (a byB) Len() int           { return len(a) }
+func (a byB) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byB) Less(i, j int) bool { return a[i].b.Sub(a[j].b).Nanoseconds() < 0 }
+
+func (ps *printSender) Send(ctx *interface{}, ts *[]timeFunc) {
+	if ts == nil || len(*ts) < 2 {
+		return
+	}
+	var threshold time.Duration
+	mt, err := util.EnvInt("METRICS_THRESHOLD_MS")
+	if err == nil {
+		threshold = time.Millisecond * time.Duration(mt)
+	} else {
+		threshold = time.Millisecond * 5000
+	}
+	first := (*ts)[0]
+	last := (*ts)[len(*ts)-1]
+	if last.d.Sub(last.b) < threshold {
+		return
+	}
+	s := fmt.Sprintf("%v: metrics context: %v\n", first.b, *ctx)
+
+	sort.Sort(byB(*ts))
+	for _, tf := range (*ts)[1:] {
+		if len(tf.w) > 0 {
+			s += fmt.Sprintf("@%vms: %v--%v, duration: %vms, ts:%v\n", float64(tf.b.Sub(first.b).Microseconds())/1000, tf.f, tf.w, float64(tf.d.Sub(tf.b).Microseconds())/1000, tf.b)
+		} else {
+			s += fmt.Sprintf("@%vms: %v, duration: %vms\n", float64(tf.b.Sub(first.b).Microseconds())/1000, tf.f, float64(tf.d.Sub(tf.b).Microseconds())/1000)
+		}
+	}
+	fmt.Println(s)
+}
+
+//
+
+type dummyMetrics struct {
+}
+
+func (m *dummyMetrics) MarkTime(b time.Time) Metrics {
+	return m
+}
+
+func (m *dummyMetrics) MarkTimeWith(s string) Metrics {
+	return m
+}
+
+func (m *dummyMetrics) ReportAndClose(time.Time) {
+}

--- a/server/server.go
+++ b/server/server.go
@@ -226,8 +226,8 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 
 				if cr.Kind == caching.RevalidatingReader {
 					alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "revalidated")
-				} else {
-					alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "hit")
+				} else if cr.Kind == caching.NotFoundReader {
+					alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "miss")
 				}
 
 				clearAndCopyHeaders(*w, cr.Metadata.Header, *alwaysInclude)

--- a/server/server.go
+++ b/server/server.go
@@ -224,7 +224,11 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 					return
 				}
 
-				alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "hit")
+				if cr.Kind == caching.RevalidatingReader {
+					alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "revalidated")
+				} else {
+					alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "hit")
+				}
 
 				clearAndCopyHeaders(*w, cr.Metadata.Header, *alwaysInclude)
 				(*w).WriteHeader(cr.Metadata.Status)

--- a/util/env.go
+++ b/util/env.go
@@ -1,5 +1,31 @@
 package util
 
+import (
+	"errors"
+	"os"
+	"strconv"
+)
+
 func EnvBool(s string) bool {
-	return s == "1" || s == "true" || s == "True" || s == "yes"
+	v := os.Getenv(s)
+	if len(v) == 0 {
+		return false
+	}
+
+	return v == "1" || v == "true" || v == "True" || v == "yes"
+}
+
+func EnvInt(s string) (int, error) {
+	v := os.Getenv(s)
+	if len(v) == 0 {
+		return 0, errors.New("no value")
+	}
+
+	var vi int
+	var err error
+	if vi, err = strconv.Atoi(v); err != nil {
+		return 0, err
+	}
+
+	return vi, nil
 }


### PR DESCRIPTION
- Ditches the mutex in disk.go in favor of a single function ingesting accessed items from a channel to record
- Report revalidating reader results as "revalidated" and entry-not-found readers as "miss"
- Fix a bug in cache-control directive usage where no-cache was parsed but not used