### PR TITLE
Flatten redirects -> restart on redirect, request header overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ rules:
       hostheader: app2.example.com:9000
 ```
 
+## Request header overriding
+
+A rule with
+```yaml
+request_headers:
+  authorization: null
+  foo: bar
+```
+
+applies all keys and their values to the request headers, prior to sending the request to the origin. A special value, `null`, can be used to remove a header.
+
 ## Response header overriding
 
 A rule with
@@ -163,7 +174,7 @@ A rule with
 response_headers:
   access-control-allow-origin: "*"
 ```
-applies all keys and their values the response headers. Whitespace is trimmed from both the key and value.
+applies all keys and their values to the response headers. Whitespace is trimmed from both the key and value.
 
 ## Traffic Copying
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ response_headers:
 ```
 applies all keys and their values to the response headers. Whitespace is trimmed from both the key and value.
 
+## Restart on redirect
+
+A rule with
+```yaml
+restart_on_redirect: true
+```
+will cause the URL in the `Location` header to be requested as if the request was made by the client, using the same method and headers. When a cache is used, each redirected URL is cached as a separate entry.
+
+For example, with a set of rules being
+```yaml
+rules:
+  - path: /config/v1/*
+    destination: https://richie-appconfig.example.com/v1/$1
+    restart_on_redirect: true
+  - path: /config/v2/*
+    host: external-host.example.com
+    destination: https://external-host.example.com/$1
+    request_headers:
+      authorization: null
+    cache: c1
+```
+and a request with an `authorization` header to `app.example.com/config/v1/*`, where a redirection from `https://richie-appconfig.example.com/v1/$1` to `https://external-host.example.com/config/v2/*` will result in that URL being requested by rrrouter, with the `authorization` header dropped. In this case, an "outer" request with user-specific credentials would not be cached, while the "inner" redirection would be cached for all following requests, as the user-specific credentials are dropped before requesting that resource.
+
 ## Traffic Copying
 
 In addition to proxying requests, rrrouter can copy traffic to a host without reporting this to the user.

--- a/caching/caching.go
+++ b/caching/caching.go
@@ -459,7 +459,7 @@ func (k Key) HasFullOrigin() bool {
 	return k.opaqueOrigin == false && len(k.storedHeaders.Get("origin")) > 0
 }
 
-var keyClientHeaders = []string{"host", "accept-encoding"}
+var keyClientHeaders = []string{"host", "accept-encoding", "authorization"}
 var HeaderRrrouterCacheStatus = "richie-edge-cache"
 
 type cacheConfig struct {

--- a/caching/caching.go
+++ b/caching/caching.go
@@ -574,6 +574,7 @@ type CachingResponseWriter interface {
 	ReadFrom(r io.Reader) (n int64, err error)
 	SetClientWritesDisabled()
 	GetClientWritesDisabled() bool
+	SetDiskWritesDisabled()
 	SetRedirectedURL(*url.URL)
 	SetRevalidatedAndClose() error
 	SetRevalidateErroredAndClose(bool) error
@@ -582,6 +583,7 @@ type CachingResponseWriter interface {
 type cachingResponseWriter struct {
 	clientWriter         http.ResponseWriter
 	clientWritesDisabled bool
+	diskWritesDisabled   bool
 	cacheWriter          CacheWriter
 	log                  *apexlog.Logger
 }
@@ -591,6 +593,9 @@ func (crw *cachingResponseWriter) Header() http.Header {
 }
 
 func (crw *cachingResponseWriter) Write(ba []byte) (int, error) {
+	if crw.diskWritesDisabled {
+		return len(ba), nil
+	}
 	return crw.cacheWriter.Write(ba)
 }
 
@@ -609,7 +614,7 @@ func (crw *cachingResponseWriter) WriteHeader(statusCode int) {
 			cleanedHeaders.Set("content-length", cl)
 		}
 	}
-	if crw.cacheWriter != nil {
+	if crw.cacheWriter != nil && !crw.diskWritesDisabled {
 		if statusCode == 200 || IsCacheableError(statusCode) || util.IsRedirect(statusCode) {
 			if cleanedHeaders != nil {
 				crw.cacheWriter.WriteHeader(statusCode, cleanedHeaders)
@@ -621,18 +626,30 @@ func (crw *cachingResponseWriter) WriteHeader(statusCode int) {
 }
 
 func (crw *cachingResponseWriter) Flush() {
+	if crw.diskWritesDisabled {
+		return
+	}
 	crw.cacheWriter.Flush()
 }
 
 func (crw *cachingResponseWriter) Close() error {
+	if crw.diskWritesDisabled {
+		return nil
+	}
 	return crw.cacheWriter.Close()
 }
 
 func (crw *cachingResponseWriter) WrittenFile() (*os.File, error) {
+	if crw.diskWritesDisabled {
+		return nil, nil
+	}
 	return crw.cacheWriter.WrittenFile()
 }
 
 func (crw *cachingResponseWriter) ChangeKey(k Key) error {
+	if crw.diskWritesDisabled {
+		return nil
+	}
 	return crw.cacheWriter.ChangeKey(k)
 }
 
@@ -648,21 +665,37 @@ func (crw *cachingResponseWriter) GetClientWritesDisabled() bool {
 	return crw.clientWritesDisabled
 }
 
+func (crw *cachingResponseWriter) SetDiskWritesDisabled() {
+	crw.diskWritesDisabled = true
+}
+
 func (crw *cachingResponseWriter) SetRedirectedURL(redir *url.URL) {
+	if crw.diskWritesDisabled {
+		return
+	}
 	crw.cacheWriter.SetRedirectedURL(redir)
 }
 
 func (crw *cachingResponseWriter) SetRevalidatedAndClose() error {
+	if crw.diskWritesDisabled {
+		return nil
+	}
 	crw.cacheWriter.SetRevalidated()
 	return crw.cacheWriter.Close()
 }
 
 func (crw *cachingResponseWriter) SetRevalidateErroredAndClose(canStaleIfError bool) error {
+	if crw.diskWritesDisabled {
+		return nil
+	}
 	crw.cacheWriter.SetRevalidateErrored(canStaleIfError)
 	return crw.cacheWriter.Close()
 }
 
 func (crw *cachingResponseWriter) Delete() error {
+	if crw.diskWritesDisabled {
+		return nil
+	}
 	err := crw.cacheWriter.Delete()
 	if err != nil {
 		crw.log.WithField("error", err).Error("Could not clean up stray file after error")

--- a/integrationtest/caching_test.go
+++ b/integrationtest/caching_test.go
@@ -1661,7 +1661,7 @@ func TestCache_recursive_redirects_not_allowed(t *testing.T) {
 	require.Equal(t, 2, timesOriginHit)
 }
 
-func TestCache_restart_on_redirect_relative_redirects_use_rule_destination_host(t *testing.T) {
+func TestCache_restart_on_redirect_relative_redirects_use_destination_host(t *testing.T) {
 	sh := setup(t)
 	now = time.Now()
 	timesOriginHit := 0

--- a/integrationtest/successful_gets_test.go
+++ b/integrationtest/successful_gets_test.go
@@ -933,10 +933,10 @@ func TestConnection_flatten_redirects_follows_all_redirections(t *testing.T) {
 
 	rules, err := proxy.NewRules([]proxy.RuleSource{
 		{
-			Path:             "/t/matches/*",
-			Destination:      fmt.Sprintf("%s/$1", targetServer.URL),
-			Internal:         false,
-			FlattenRedirects: true,
+			Path:              "/t/matches/*",
+			Destination:       fmt.Sprintf("%s/$1", targetServer.URL),
+			Internal:          false,
+			RestartOnRedirect: true,
 		},
 	}, sh.Logger)
 	require.Nil(t, err)

--- a/integrationtest/successful_gets_test.go
+++ b/integrationtest/successful_gets_test.go
@@ -904,7 +904,7 @@ func TestConnection_redirects_pass_rrrouter_by_default(t *testing.T) {
 	}
 }
 
-func TestConnection_flatten_redirects_follows_all_redirections(t *testing.T) {
+func TestConnection_restart_on_redirect_follows_all_redirections(t *testing.T) {
 	sh := setup(t)
 	conf := &config.Config{
 		Port:       0,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -37,7 +37,7 @@ type RequestResult struct {
 
 // Router is the meat of rrrouter
 type Router interface {
-	RouteRequest(context.Context, *http.Request, *url.URL, *map[string]interface{}, *Rule) (*RequestResult, error)
+	RouteRequest(context.Context, *http.Request, *url.URL, *Rule) (*RequestResult, error)
 	GetRoutingFlavors(*http.Request) RoutingFlavors
 	SetRules(*Rules)
 }
@@ -46,7 +46,7 @@ type RoutingFlavors struct {
 	CacheId           string
 	ForceRevalidate   int
 	RestartOnRedirect bool
-	RequestHeaders    map[string]interface{}
+	RequestHeaders    map[string]*string
 	ResponseHeaders   http.Header
 	Rule              *Rule
 }
@@ -155,7 +155,7 @@ type rrErr struct {
 	err    error
 }
 
-func (r *router) RouteRequest(ctx context.Context, req *http.Request, overrideURL *url.URL, overrideHeaders *map[string]interface{}, fallbackRule *Rule) (*RequestResult, error) {
+func (r *router) RouteRequest(ctx context.Context, req *http.Request, overrideURL *url.URL, fallbackRule *Rule) (*RequestResult, error) {
 	logctx := r.logger.WithFields(apexlog.Fields{"func": "router.RouteRequest"})
 	logctx.Debug("Enter")
 	urlMatch, err := r.createUrlMatch(req, nil, logctx)
@@ -164,7 +164,7 @@ func (r *router) RouteRequest(ctx context.Context, req *http.Request, overrideUR
 	}
 
 	ch := make(chan rrErr, 1)
-	go r.routeRequest(ctx, ch, urlMatch, req, overrideHeaders, overrideURL, fallbackRule, logctx)
+	go r.routeRequest(ctx, ch, urlMatch, req, overrideURL, fallbackRule, logctx)
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -183,8 +183,8 @@ func (r *router) createUrlMatch(req *http.Request, overrideRules *Rules, logctx 
 	return urlMatch, nil
 }
 
-func (r *router) routeRequest(ctx context.Context, ch chan rrErr, urlMatch *urlMatch, req *http.Request, overrideHeaders *map[string]interface{}, overrideURL *url.URL, fallbackRule *Rule, logctx *apexlog.Entry) {
-	requestsResult, err := r.createOutgoingRequests(urlMatch, req, overrideURL, overrideHeaders, fallbackRule)
+func (r *router) routeRequest(ctx context.Context, ch chan rrErr, urlMatch *urlMatch, req *http.Request, overrideURL *url.URL, fallbackRule *Rule, logctx *apexlog.Entry) {
+	requestsResult, err := r.createOutgoingRequests(urlMatch, req, overrideURL, fallbackRule)
 	if err != nil {
 		logctx.WithError(err).Error("error creating outgoing request")
 		ch <- rrErr{nil, err}
@@ -257,7 +257,7 @@ func (r *router) routeRequest(ctx context.Context, ch chan rrErr, urlMatch *urlM
 				ch <- rrErr{nil, err}
 				return
 			}
-			r.routeRequest(ctx, ch, urlMatch, req, nil, nil, nil, logctx)
+			r.routeRequest(ctx, ch, urlMatch, req, nil, nil, logctx)
 			return
 		} else if err != nil {
 			logctx.WithError(err).Error("Error performing main request")
@@ -493,7 +493,7 @@ func (r *router) RuleForCaching(req *http.Request) (*Rule, error) {
 	return nil, nil
 }
 
-func (r *router) createOutgoingRequests(urlMatch *urlMatch, req *http.Request, overrideURL *url.URL, overrideHeaders *map[string]interface{}, fallbackRule *Rule) (*createRequestsResult, error) {
+func (r *router) createOutgoingRequests(urlMatch *urlMatch, req *http.Request, overrideURL *url.URL, fallbackRule *Rule) (*createRequestsResult, error) {
 	logctx := r.logger.WithFields(apexlog.Fields{"func": "router.createOutgoingRequest"})
 	var mainRequest *http.Request
 	var err error
@@ -520,7 +520,7 @@ func (r *router) createOutgoingRequests(urlMatch *urlMatch, req *http.Request, o
 		} else {
 			u = urlMatch.url
 		}
-		mainRequest, err = r.createProxyRequest(req, rule.internal, rule.hostHeader, u, overrideHeaders)
+		mainRequest, err = r.createProxyRequest(req, rule.internal, rule.hostHeader, u)
 		if err != nil {
 			logctx.WithError(err).Error("Error creating mainRequest")
 			return nil, err
@@ -531,7 +531,7 @@ func (r *router) createOutgoingRequests(urlMatch *urlMatch, req *http.Request, o
 	}
 	var copyRequest *http.Request
 	if urlMatch.copyURL != nil {
-		copyRequest, err = r.createProxyRequest(req, urlMatch.copyRule.internal, urlMatch.copyRule.hostHeader, urlMatch.copyURL, overrideHeaders)
+		copyRequest, err = r.createProxyRequest(req, urlMatch.copyRule.internal, urlMatch.copyRule.hostHeader, urlMatch.copyURL)
 		if err != nil {
 			logctx.WithError(err).Error("Error creating copyRequest")
 			return nil, err
@@ -566,7 +566,7 @@ func filterHeader(originalHeader http.Header, filteredHeaderNames []string) http
 	return newHeader
 }
 
-func (r *router) createProxyRequest(req *http.Request, internal bool, hostHeader HostHeader, url *url.URL, overrideHeaders *map[string]interface{}) (*http.Request, error) {
+func (r *router) createProxyRequest(req *http.Request, internal bool, hostHeader HostHeader, url *url.URL) (*http.Request, error) {
 	logctx := r.logger.WithFields(apexlog.Fields{"func": "router.createProxyRequest", "url": url})
 	logctx.Debug("Constructing outgoing request")
 	preq, err := http.NewRequestWithContext(req.Context(), req.Method, url.String(), req.Body)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -119,6 +119,9 @@ func NewRouter(rules *Rules, logger *apexlog.Logger, conf *config.Config) Router
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
+			Resolver: &net.Resolver{
+				PreferGo: true,
+			},
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -300,7 +300,7 @@ func (r *router) follow(ctx context.Context, req *http.Request, requestData []by
 				return nil, nil, err
 			}
 
-			req.URL = util.RedirectedURL(req, redirectedURL)
+			req.URL = util.RedirectedURL(req, req.URL, redirectedURL)
 			req.Host = req.URL.Host
 			requestData = nil
 		} else {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -719,7 +719,7 @@ func destinationString(u *url.URL) string {
 	}
 	u2 := *u
 	u2.Host = util.DropPort(u2.Host)
-	u2.RawQuery = ""
+	//u2.RawQuery = ""
 	return u2.String()
 }
 

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -8,22 +8,22 @@ import (
 
 // Rule describes a single forwarding rule
 type Rule struct {
-	enabled          bool
-	scheme           string
-	host             string
-	path             string
-	wci              []int
-	dest             string
-	internal         bool
-	methods          map[string]bool
-	ruleType         ruleType
-	recompression    bool
-	hostHeader       HostHeader
-	cacheId          string
-	forceRevalidate  int
-	responseHeaders  map[string]string
-	flattenRedirects bool
-	retryRule        *Rule
+	enabled           bool
+	scheme            string
+	host              string
+	path              string
+	wci               []int
+	dest              string
+	internal          bool
+	methods           map[string]bool
+	ruleType          ruleType
+	recompression     bool
+	hostHeader        HostHeader
+	cacheId           string
+	forceRevalidate   int
+	responseHeaders   map[string]string
+	restartOnRedirect bool
+	retryRule         *Rule
 }
 
 type HostHeader struct {
@@ -42,7 +42,7 @@ const (
 
 // NewRule builds a new Rule
 func NewRule(enabled bool, scheme, host, path, destination string, internal bool, methods map[string]bool, ruleType ruleType, hostHeader HostHeader,
-	recompression bool, cacheId string, forceRevalidate int, responseHeaders map[string]string, flattenRedirects bool, retryRule *Rule) (*Rule, error) {
+	recompression bool, cacheId string, forceRevalidate int, responseHeaders map[string]string, restartOnRedirect bool, retryRule *Rule) (*Rule, error) {
 	if len(path) == 0 {
 		return nil, errors.New("Empty path")
 	}
@@ -63,22 +63,22 @@ func NewRule(enabled bool, scheme, host, path, destination string, internal bool
 	}
 
 	rule := &Rule{
-		enabled:          enabled,
-		scheme:           scheme,
-		host:             host,
-		path:             path,
-		wci:              wci,
-		dest:             destination,
-		internal:         internal,
-		methods:          methods,
-		ruleType:         ruleType,
-		hostHeader:       hostHeader,
-		recompression:    recompression,
-		cacheId:          cacheId,
-		forceRevalidate:  forceRevalidate,
-		responseHeaders:  responseHeaders,
-		flattenRedirects: flattenRedirects,
-		retryRule:        retryRule,
+		enabled:           enabled,
+		scheme:            scheme,
+		host:              host,
+		path:              path,
+		wci:               wci,
+		dest:              destination,
+		internal:          internal,
+		methods:           methods,
+		ruleType:          ruleType,
+		hostHeader:        hostHeader,
+		recompression:     recompression,
+		cacheId:           cacheId,
+		forceRevalidate:   forceRevalidate,
+		responseHeaders:   responseHeaders,
+		restartOnRedirect: restartOnRedirect,
+		retryRule:         retryRule,
 	}
 
 	return rule, nil

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -21,6 +21,7 @@ type Rule struct {
 	hostHeader        HostHeader
 	cacheId           string
 	forceRevalidate   int
+	requestHeaders    map[string]interface{}
 	responseHeaders   map[string]string
 	restartOnRedirect bool
 	retryRule         *Rule
@@ -42,7 +43,8 @@ const (
 
 // NewRule builds a new Rule
 func NewRule(enabled bool, scheme, host, path, destination string, internal bool, methods map[string]bool, ruleType ruleType, hostHeader HostHeader,
-	recompression bool, cacheId string, forceRevalidate int, responseHeaders map[string]string, restartOnRedirect bool, retryRule *Rule) (*Rule, error) {
+	recompression bool, cacheId string, forceRevalidate int, requestHeaders map[string]interface{}, responseHeaders map[string]string,
+	restartOnRedirect bool, retryRule *Rule) (*Rule, error) {
 	if len(path) == 0 {
 		return nil, errors.New("Empty path")
 	}
@@ -76,6 +78,7 @@ func NewRule(enabled bool, scheme, host, path, destination string, internal bool
 		recompression:     recompression,
 		cacheId:           cacheId,
 		forceRevalidate:   forceRevalidate,
+		requestHeaders:    requestHeaders,
 		responseHeaders:   responseHeaders,
 		restartOnRedirect: restartOnRedirect,
 		retryRule:         retryRule,

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -25,6 +27,21 @@ type Rule struct {
 	responseHeaders   map[string]string
 	restartOnRedirect bool
 	retryRule         *Rule
+}
+
+func (rule Rule) OverrideOnRequest(r *http.Request) *http.Request {
+	destStr, err := rule.attemptMatch(r.URL.Scheme, r.URL.Host, r.URL.RequestURI())
+	if destStr == nil || err != nil {
+		return r
+	}
+
+	u, err := url.Parse(*destStr)
+	if err != nil {
+		return r
+	}
+	r.URL = u
+
+	return r
 }
 
 type HostHeader struct {

--- a/proxy/rule.go
+++ b/proxy/rule.go
@@ -23,7 +23,7 @@ type Rule struct {
 	hostHeader        HostHeader
 	cacheId           string
 	forceRevalidate   int
-	requestHeaders    map[string]interface{}
+	requestHeaders    map[string]*string
 	responseHeaders   map[string]string
 	restartOnRedirect bool
 	retryRule         *Rule
@@ -60,7 +60,7 @@ const (
 
 // NewRule builds a new Rule
 func NewRule(enabled bool, scheme, host, path, destination string, internal bool, methods map[string]bool, ruleType ruleType, hostHeader HostHeader,
-	recompression bool, cacheId string, forceRevalidate int, requestHeaders map[string]interface{}, responseHeaders map[string]string,
+	recompression bool, cacheId string, forceRevalidate int, requestHeaders map[string]*string, responseHeaders map[string]string,
 	restartOnRedirect bool, retryRule *Rule) (*Rule, error) {
 	if len(path) == 0 {
 		return nil, errors.New("Empty path")

--- a/proxy/rule_test.go
+++ b/proxy/rule_test.go
@@ -98,7 +98,7 @@ func TestRule(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r, err := NewRule(true, test.scheme, test.host, test.pat, test.dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false, "", 0, map[string]string{}, false, nil)
+		r, err := NewRule(true, test.scheme, test.host, test.pat, test.dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false, "", 0, nil, map[string]string{}, false, nil)
 		if err != nil && !test.shouldError {
 			t.Errorf("Unexpected error compiling rule from %q, %q: %s", test.pat, test.dest, err)
 			continue

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -114,10 +114,14 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 		if rsrc.ForceRevalidate > 0 {
 			forceRevalidate = rsrc.ForceRevalidate
 		}
-		requestHeaders := make(map[string]interface{}, 0)
+		requestHeaders := make(map[string]*string, 0)
 		if len(rsrc.RequestHeaders) > 0 {
 			for k, v := range rsrc.RequestHeaders {
-				requestHeaders[strings.ToLower(strings.TrimSpace(k))] = v
+				if v == nil {
+					requestHeaders[strings.ToLower(strings.TrimSpace(k))] = nil
+				} else if val, ok := v.(string); ok {
+					requestHeaders[strings.ToLower(strings.TrimSpace(k))] = &val
+				}
 			}
 		}
 		responseHeaders := make(map[string]string, 0)

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -37,21 +37,22 @@ var (
 
 // RuleSource is a source of rules, e.g. a JSON file
 type RuleSource struct {
-	Enabled           *bool             `json:"enabled"`
-	Methods           []string          `json:"methods"`
-	Scheme            string            `json:"scheme"`
-	Host              string            `json:"host"`
-	Path              string            `json:"path"`
-	Destination       string            `json:"destination"`
-	Internal          bool              `json:"internal"`
-	Type              *string           `json:"type"`
-	HostHeader        string            `json:"hostheader"`
-	Recompression     bool              `json:"recompression"`
-	CacheId           string            `json:"cache"`
-	ForceRevalidate   int               `json:"force_revalidate"`
-	ResponseHeaders   map[string]string `json:"response_headers"`
-	RestartOnRedirect bool              `json:"restart_on_redirect"`
-	RetryRule         *RuleSource       `json:"retry_rule"`
+	Enabled           *bool                  `json:"enabled"`
+	Methods           []string               `json:"methods"`
+	Scheme            string                 `json:"scheme"`
+	Host              string                 `json:"host"`
+	Path              string                 `json:"path"`
+	Destination       string                 `json:"destination"`
+	Internal          bool                   `json:"internal"`
+	Type              *string                `json:"type"`
+	HostHeader        string                 `json:"hostheader"`
+	Recompression     bool                   `json:"recompression"`
+	CacheId           string                 `json:"cache"`
+	ForceRevalidate   int                    `json:"force_revalidate"`
+	RequestHeaders    map[string]interface{} `json:"request_headers"`
+	ResponseHeaders   map[string]string      `json:"response_headers"`
+	RestartOnRedirect bool                   `json:"restart_on_redirect"`
+	RetryRule         *RuleSource            `json:"retry_rule"`
 }
 
 type rulesConfig struct {
@@ -113,6 +114,12 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 		if rsrc.ForceRevalidate > 0 {
 			forceRevalidate = rsrc.ForceRevalidate
 		}
+		requestHeaders := make(map[string]interface{}, 0)
+		if len(rsrc.RequestHeaders) > 0 {
+			for k, v := range rsrc.RequestHeaders {
+				requestHeaders[strings.ToLower(strings.TrimSpace(k))] = v
+			}
+		}
 		responseHeaders := make(map[string]string, 0)
 		if len(rsrc.ResponseHeaders) > 0 {
 			for k, v := range rsrc.ResponseHeaders {
@@ -133,7 +140,7 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 				retryRule = rRules.rules[0]
 			}
 		}
-		rule, err := NewRule(enabled, rsrc.Scheme, rsrc.Host, rsrc.Path, rsrc.Destination, rsrc.Internal, methodMap, ruleType, hostHeader, recompression, cacheId, forceRevalidate, responseHeaders, restartOnRedirect, retryRule)
+		rule, err := NewRule(enabled, rsrc.Scheme, rsrc.Host, rsrc.Path, rsrc.Destination, rsrc.Internal, methodMap, ruleType, hostHeader, recompression, cacheId, forceRevalidate, requestHeaders, responseHeaders, restartOnRedirect, retryRule)
 		if err != nil {
 			return nil, err
 		}

--- a/proxy/ruleconfig.go
+++ b/proxy/ruleconfig.go
@@ -37,21 +37,21 @@ var (
 
 // RuleSource is a source of rules, e.g. a JSON file
 type RuleSource struct {
-	Enabled          *bool             `json:"enabled"`
-	Methods          []string          `json:"methods"`
-	Scheme           string            `json:"scheme"`
-	Host             string            `json:"host"`
-	Path             string            `json:"path"`
-	Destination      string            `json:"destination"`
-	Internal         bool              `json:"internal"`
-	Type             *string           `json:"type"`
-	HostHeader       string            `json:"hostheader"`
-	Recompression    bool              `json:"recompression"`
-	CacheId          string            `json:"cache"`
-	ForceRevalidate  int               `json:"force_revalidate"`
-	ResponseHeaders  map[string]string `json:"response_headers"`
-	FlattenRedirects bool              `json:"flatten_redirects"`
-	RetryRule        *RuleSource       `json:"retry_rule"`
+	Enabled           *bool             `json:"enabled"`
+	Methods           []string          `json:"methods"`
+	Scheme            string            `json:"scheme"`
+	Host              string            `json:"host"`
+	Path              string            `json:"path"`
+	Destination       string            `json:"destination"`
+	Internal          bool              `json:"internal"`
+	Type              *string           `json:"type"`
+	HostHeader        string            `json:"hostheader"`
+	Recompression     bool              `json:"recompression"`
+	CacheId           string            `json:"cache"`
+	ForceRevalidate   int               `json:"force_revalidate"`
+	ResponseHeaders   map[string]string `json:"response_headers"`
+	RestartOnRedirect bool              `json:"restart_on_redirect"`
+	RetryRule         *RuleSource       `json:"retry_rule"`
 }
 
 type rulesConfig struct {
@@ -119,9 +119,9 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 				responseHeaders[strings.TrimSpace(k)] = strings.TrimSpace(v)
 			}
 		}
-		flattenRedirects := false
-		if rsrc.FlattenRedirects {
-			flattenRedirects = true
+		restartOnRedirect := false
+		if rsrc.RestartOnRedirect {
+			restartOnRedirect = true
 		}
 		var retryRule *Rule
 		if rsrc.RetryRule != nil {
@@ -133,7 +133,7 @@ func NewRules(ruleSources []RuleSource, logger *apexlog.Logger) (*Rules, error) 
 				retryRule = rRules.rules[0]
 			}
 		}
-		rule, err := NewRule(enabled, rsrc.Scheme, rsrc.Host, rsrc.Path, rsrc.Destination, rsrc.Internal, methodMap, ruleType, hostHeader, recompression, cacheId, forceRevalidate, responseHeaders, flattenRedirects, retryRule)
+		rule, err := NewRule(enabled, rsrc.Scheme, rsrc.Host, rsrc.Path, rsrc.Destination, rsrc.Internal, methodMap, ruleType, hostHeader, recompression, cacheId, forceRevalidate, responseHeaders, restartOnRedirect, retryRule)
 		if err != nil {
 			return nil, err
 		}

--- a/proxy/ruleconfig_test.go
+++ b/proxy/ruleconfig_test.go
@@ -221,7 +221,37 @@ func TestConfigParse_host_headers(t *testing.T) {
 	require.Equal(t, HostHeaderOverride, rules.rules[2].hostHeader.Behavior)
 	require.Equal(t, "example.com:3800", rules.rules[2].hostHeader.Override)
 	require.Equal(t, HostHeaderDestination, rules.rules[3].hostHeader.Behavior)
+}
 
+func TestConfigParse_request_headers(t *testing.T) {
+	src := `{"rules": [
+        {
+			"host": "api.example.com",
+            "path": "/foo/*",  
+            "destination": "http://localhost:1000/v1/$1",
+			"request_headers": {"authorization": null, "x-foo": "bar"}
+		}
+        ]
+    }`
+	rules, err := ParseRules([]byte(src), testhelp.NewLogger(t))
+	require.Nil(t, err)
+	require.Equal(t, nil, rules.rules[0].requestHeaders["authorization"])
+	require.Equal(t, "bar", rules.rules[0].requestHeaders["x-foo"])
+}
+
+func TestConfigParse_response_headers(t *testing.T) {
+	src := `{"rules": [
+        {
+			"host": "api.example.com",
+            "path": "/foo/*",  
+            "destination": "http://localhost:1000/v1/$1",
+			"response_headers": {"acao": " * "}
+		}
+        ]
+    }`
+	rules, err := ParseRules([]byte(src), testhelp.NewLogger(t))
+	require.Nil(t, err)
+	require.Equal(t, "*", rules.rules[0].responseHeaders["acao"])
 }
 
 func TestConfigParse_destination_can_omit_wildcard_placement_marker(t *testing.T) {

--- a/proxy/ruleconfig_test.go
+++ b/proxy/ruleconfig_test.go
@@ -235,8 +235,12 @@ func TestConfigParse_request_headers(t *testing.T) {
     }`
 	rules, err := ParseRules([]byte(src), testhelp.NewLogger(t))
 	require.Nil(t, err)
-	require.Equal(t, nil, rules.rules[0].requestHeaders["authorization"])
-	require.Equal(t, "bar", rules.rules[0].requestHeaders["x-foo"])
+	val, exists := rules.rules[0].requestHeaders["authorization"]
+	require.Equal(t, exists, true)
+	var nilval *string = nil
+	require.Equal(t, nilval, val)
+	var barval = "bar"
+	require.Equal(t, &barval, rules.rules[0].requestHeaders["x-foo"])
 }
 
 func TestConfigParse_response_headers(t *testing.T) {

--- a/proxy/urlcreate_test.go
+++ b/proxy/urlcreate_test.go
@@ -57,7 +57,7 @@ func uparse(s string) *url.URL {
 }
 
 func createRule(s, h, path, dest string) *Rule {
-	r, err := NewRule(true, s, h, path, dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false, "", 0, map[string]string{}, false, nil)
+	r, err := NewRule(true, s, h, path, dest, false, map[string]bool{}, ruleTypeProxy, HostHeader{Behavior: HostHeaderDefault}, false, "", 0, nil, map[string]string{}, false, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 
 			switch cr.Kind {
 			case caching.Found:
-				if rf.FlattenRedirects && util.IsRedirect(cr.Metadata.Status) {
+				if rf.RestartOnRedirect && util.IsRedirect(cr.Metadata.Status) {
 					rr, err := requestWithRedirect(r, cr.Metadata.RedirectedURL)
 					if err != nil {
 						cache.Finish(key, logger)
@@ -235,7 +235,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 					return
 				}
 
-				if rf.FlattenRedirects && util.IsRedirect(cr.Metadata.Status) {
+				if rf.RestartOnRedirect && util.IsRedirect(cr.Metadata.Status) {
 					rr, err := requestWithRedirect(r, cr.Metadata.RedirectedURL)
 					if err != nil {
 						writeError(*w, err)
@@ -361,7 +361,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 						redirectedUrl.Scheme = reqres.OriginalURL.Scheme
 						redirectedUrl.Host = reqres.OriginalURL.Host
 						cr.Writer.SetRedirectedURL(redirectedUrl)
-						if rf.FlattenRedirects {
+						if rf.RestartOnRedirect {
 							rr := r.Clone(r.Context())
 							rr.URL = redirectedUrl
 							rr.Host = redirectedUrl.Host

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 				return
 			}
 
-			keys := caching.KeysFromRequest(r)
+			keys := caching.KeysFromRequest(ruleDestinationRequest(r, *rf.Rule))
 			cr, key, err := cache.Get(ctx, rf.CacheId, rf.ForceRevalidate, skipRevalidate, keys, *w, logger)
 			if err != nil {
 				cache.Finish(key, logger)
@@ -405,6 +405,10 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 		}
 		cachingFunc(&ow, or, nil, nil, nil, false)
 	}
+}
+
+func ruleDestinationRequest(r *http.Request, rule proxy.Rule) *http.Request {
+	return rule.OverrideOnRequest(r.Clone(context.Background()))
 }
 
 func preprocessHeaders(r *http.Request, overrides map[string]interface{}) *http.Request {

--- a/server/server.go
+++ b/server/server.go
@@ -357,9 +357,8 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 							writeError(*w, err)
 							return
 						}
-						redirectedUrl := util.RedirectedURL(r, reqres.RedirectedURL)
+						redirectedUrl := util.RedirectedURL(r, reqres.OriginalURL, reqres.RedirectedURL)
 						redirectedUrl.Scheme = reqres.OriginalURL.Scheme
-						redirectedUrl.Host = reqres.OriginalURL.Host
 						cr.Writer.SetRedirectedURL(redirectedUrl)
 						if rf.RestartOnRedirect {
 							rr := r.Clone(r.Context())
@@ -420,7 +419,7 @@ func requestWithRedirect(r *http.Request, location string) (*http.Request, error
 		return nil, err
 	}
 	rr := r.Clone(r.Context())
-	rr.URL = util.RedirectedURL(rr, locationUrl)
+	rr.URL = util.RedirectedURL(rr, rr.URL, locationUrl)
 	rr.Host = rr.URL.Host
 	return rr, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -680,6 +680,9 @@ func makeCachingWriteBody(rr *requestRange) BodyWriter {
 			}
 		}
 		if !ok {
+			if errCleanup != nil {
+				errCleanup()
+			}
 			panic(fmt.Sprintf("Caching writer missing"))
 		}
 
@@ -689,6 +692,9 @@ func makeCachingWriteBody(rr *requestRange) BodyWriter {
 
 		fd, err := crw.WrittenFile()
 		if err != nil {
+			if errCleanup != nil {
+				errCleanup()
+			}
 			return err
 		}
 		if fd != nil {
@@ -697,11 +703,17 @@ func makeCachingWriteBody(rr *requestRange) BodyWriter {
 
 		fi, err := fd.Stat()
 		if err != nil {
+			if errCleanup != nil {
+				errCleanup()
+			}
 			return err
 		}
 
 		_, err = sendBody(crw.GetClientWriter(), fd, fi.Size(), rr, logctx)
 		if err != nil {
+			if errCleanup != nil {
+				errCleanup()
+			}
 			return err
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -644,11 +644,11 @@ func makeCachingWriteBody(rr *requestRange) BodyWriter {
 		}
 
 		fd, err := crw.WrittenFile()
-		if fd != nil {
-			defer fd.Close()
-		}
 		if err != nil {
 			return err
+		}
+		if fd != nil {
+			defer fd.Close()
 		}
 
 		fi, err := fd.Stat()

--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 					rr.URL = redirectedUrl
 					rr.Host = redirectedUrl.Host
 					rr.RequestURI = reqres.RedirectedURL.RequestURI()
-					cachingFunc(w, rr, rr.URL, alwaysInclude, &rf, false)
+					cachingFunc(w, rr, nil, alwaysInclude, &rf, false)
 					return
 				}
 

--- a/server/server.go
+++ b/server/server.go
@@ -73,12 +73,12 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 			logctx := logger.WithFields(apexlog.Fields{"url": r.URL, "func": "server.cachingHandler"})
 			rf := router.GetRoutingFlavors(r)
 			r = preprocessHeaders(r, rf.RequestHeaders)
-			if alwaysInclude == nil {
-				alwaysInclude = &http.Header{}
-			}
 			shouldSkip := shouldSkipCaching(r.Header, rf)
 			if len(rf.CacheId) == 0 && frf != nil {
 				rf = *frf
+			}
+			if alwaysInclude == nil {
+				alwaysInclude = &http.Header{}
 			}
 			if len(rf.CacheId) == 0 || !cache.HasStorage(rf.CacheId) || (r.Method != "GET" && r.Method != "HEAD") {
 				reqres, err := router.RouteRequest(ctx, r, overrideURL, &rf.RequestHeaders, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -214,7 +214,6 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 					if fatal {
 						cache.Finish(key, logger)
 					}
-					writeError(*w, err)
 				}
 				return
 			case caching.NotFoundReader, caching.RevalidatingReader:

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,7 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 			if len(rf.CacheId) == 0 && frf != nil {
 				rf = *frf
 			}
-			if shouldSkip || len(rf.CacheId) == 0 || !cache.HasStorage(rf.CacheId) || (r.Method != "GET" && r.Method != "HEAD") {
+			if len(rf.CacheId) == 0 || !cache.HasStorage(rf.CacheId) || (r.Method != "GET" && r.Method != "HEAD") {
 				reqres, err := router.RouteRequest(ctx, r, overrideURL, nil)
 				if err != nil {
 					writeError(*w, err)
@@ -345,6 +345,10 @@ func cachingHandler(router proxy.Router, logger *apexlog.Logger, conf *config.Co
 						alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "revalidated")
 					} else {
 						alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "miss")
+					}
+					if shouldSkip {
+						defer cr.Writer.Delete()
+						alwaysInclude.Set(caching.HeaderRrrouterCacheStatus, "pass")
 					}
 					alwaysInclude.Set(headerAge, "0")
 					if reqres.RedirectedURL != nil {

--- a/util/http.go
+++ b/util/http.go
@@ -15,15 +15,15 @@ func IsRedirect(statusCode int) bool {
 	return false
 }
 
-func RedirectedURL(orig *http.Request, redir *url.URL) *url.URL {
+func RedirectedURL(orig *http.Request, requestedUrl *url.URL, redir *url.URL) *url.URL {
 	if len(redir.Scheme) > 0 {
 		return redir
 	} else {
 		var host string
-		if len(orig.Host) > 0 {
+		if len(requestedUrl.Host) > 0 {
+			host = requestedUrl.Host
+		} else if len(orig.Host) > 0 {
 			host = orig.Host
-		} else {
-			host = orig.URL.Host
 		}
 		if strings.Index(redir.Path, "/") == 0 {
 			newUrl := &url.URL{

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -9,18 +9,19 @@ import (
 
 func TestRedirectedURL(t *testing.T) {
 	tests := [][]string{
-		{"https://example.com/", "https://example.com/1?a=b", "https://example.com/1?a=b"},
-		{"https://example.com/", "/1?a=b", "https://example.com/1?a=b"},
-		{"https://example.com/", "1?a=b", "https://example.com/1?a=b"},
-		{"https://example.com/1?a=b", "2?b=c", "https://example.com/2?b=c"},
+		{"https://edge.example.com/", "https://inner.example.com/a", "https://example.com/1?a=b", "https://example.com/1?a=b"},
+		{"https://edge.example.com/", "https://inner.example.com/a", "/1?a=b", "https://inner.example.com/1?a=b"},
+		{"https://edge.example.com/", "https://inner.example.com", "1?b=c", "https://inner.example.com/1?b=c"},
+		{"https://edge.example.com/1?a=b", "https://inner.example.com/1?a=b", "2?c=d", "https://inner.example.com/2?c=d"},
 	}
 	for _, test := range tests {
 		origUrl, _ := url.Parse(test[0])
 		orig := &http.Request{
 			URL: origUrl,
 		}
-		redir, _ := url.Parse(test[1])
-		expected := test[2]
-		require.Equal(t, expected, RedirectedURL(orig, redir).String())
+		requestedUrl, _ := url.Parse(test[1])
+		redir, _ := url.Parse(test[2])
+		expected := test[3]
+		require.Equal(t, expected, RedirectedURL(orig, requestedUrl, redir).String())
 	}
 }

--- a/yamlconfig/yamlconfig.go
+++ b/yamlconfig/yamlconfig.go
@@ -50,6 +50,8 @@ func cleanupMapValue(v interface{}) interface{} {
 		return v
 	case string:
 		return v
+	case nil:
+		return nil
 	default:
 		return fmt.Sprintf("%v", v)
 	}


### PR DESCRIPTION
This PR renames `flatten_redirects` to `restart_on_redirect` and changes the feature to not override the redirection host. Request headers can also be overridden with a `request_headers` map, where `null` value serves to indicate that the header is to be deleted before the request is performed to the origin.

Includes various bugfixes.