### PR TITLE
Fix a possible truncation bug and don't serve mismatching entries

### DIFF
--- a/caching/disk.go
+++ b/caching/disk.go
@@ -953,7 +953,7 @@ func (sw *storageWriter) WriteHeader(s int, h http.Header) {
 		var fd *os.File
 		fd, exists, err := createIfNotExists(sw.path)
 		if exists {
-			sw.log.Infof("File already exists for key %v: %v", sw.key, sw.path)
+			//sw.log.Infof("File already exists for key %v: %v", sw.key, sw.path)
 			fd, err = os.OpenFile(sw.path, os.O_RDWR, 0)
 			if err != nil {
 				sw.log.Errorf("Can't open existing file for reading and writing: %v", sw.path)

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -1111,7 +1111,7 @@ func (sw *storageWriter) Close() error {
 		}
 	}
 
-	if sw.key.method != "HEAD" && sizeOnDisk == 0 && sw.writtenStatus != 204 && !util.IsRedirect(sw.writtenStatus) {
+	if sw.key.method != "HEAD" && sizeOnDisk == 0 && sw.writtenStatus != 204 && IsCacheableError(sw.writtenStatus) && !util.IsRedirect(sw.writtenStatus) {
 		msg := fmt.Sprintf("Size is 0. Deleting stored file")
 		sw.log.Errorf(msg)
 		sentry.WithScope(func(s *sentry.Scope) {

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -1096,7 +1096,7 @@ func (sw *storageWriter) Close() error {
 
 	if cl := sw.responseHeader.Get("content-length"); len(cl) > 0 {
 		if contentLength, err := strconv.Atoi(cl); err != nil && contentLength > 0 {
-			if int64(contentLength) != sw.writtenSize {
+			if int64(contentLength) != sw.writtenSize || int64(contentLength) != sizeOnDisk {
 				sw.log.Error(fmt.Sprintf("Written size %v did not match Content-Length header size %v. Deleting stored file.\n", sw.writtenSize, contentLength))
 				sw.Delete()
 				return errors.New(fmt.Sprintf("Size mismatch"))
@@ -1104,7 +1104,7 @@ func (sw *storageWriter) Close() error {
 		}
 	} else {
 		if sizeOnDisk != metadata.Size {
-			sw.log.Errorf("Size has changed for file %v: %v vs. %v", sw.fd.Name(), sizeOnDisk, metadata.Size)
+			sw.log.Errorf("Size has changed for file %v: %v vs. %v. wasRevalidated: %v", sw.fd.Name(), sizeOnDisk, metadata.Size, sw.wasRevalidated)
 			sw.Delete()
 			return errors.New("Size mismatch")
 		}

--- a/caching/disk.go
+++ b/caching/disk.go
@@ -325,6 +325,9 @@ func (s *storage) GetWriter(key Key, revalidate bool, closeNotifier *chan KeyInf
 		path:           fp,
 		wasRevalidated: revalidate,
 		closeFinisher: func(name string, size int64) {
+			if revalidate {
+				return
+			}
 			ai := accessedItem{
 				accessTime:    accessTime(time.Now().Unix() - s.startedAt),
 				sizeKilobytes: uint32(size / 1024),

--- a/server/server.go
+++ b/server/server.go
@@ -728,9 +728,6 @@ func makeCachingWriteBody(rr *requestRange) BodyWriter {
 
 		_, err = sendBody(crw.GetClientWriter(), fd, fi.Size(), rr, logctx)
 		if err != nil {
-			if errCleanup != nil {
-				errCleanup()
-			}
 			return err
 		}
 


### PR DESCRIPTION
Includes a fix to a possible file truncation bug and upon serving an entry from the cache, the file size is compared with what's known about it in the stored metadata.